### PR TITLE
Fix REAL_XP error

### DIFF
--- a/src/ArasakaID/KeepYourXp/Main.php
+++ b/src/ArasakaID/KeepYourXp/Main.php
@@ -41,7 +41,7 @@ class Main extends PluginBase implements Listener
             if ($type === self::DROPPED_XP) {
                 $this->playerXp[$player->getName()] = $event->getXpDropAmount();
             } elseif ($type === self::REAL_XP) {
-                $this->playerXp[$player->getName()] = $player->getXpLevel();
+                $this->playerXp[$player->getName()] = $player->getCurrentTotalXp();
             }
             $event->setXpDropAmount(0);
         }


### PR DESCRIPTION
When we put real_xp, we get the xp in number of level but give you the xp in number of xp

42 : Xp
44 : Level Xp
62 : Xp